### PR TITLE
[TBCM-61] & Issue 1 of [TBCM-62] Make Activity Gap Page Scrollable

### DIFF
--- a/apps/web/src/components/ActivitiesGapLegend.tsx
+++ b/apps/web/src/components/ActivitiesGapLegend.tsx
@@ -7,15 +7,15 @@ import { tooltipIcons } from '../common';
 export const ActivitiesGapLegend: React.FC = () => {
   const [openLegend, setOpenLegend] = useState(false);
   return (
-    <>
+    <div className='flex-1 p-2'>
       {!openLegend && (
-        <a href='#' onClick={() => setOpenLegend(true)}>
+        <a href='#' onClick={() => setOpenLegend(true)} className='font-bold text-bcBlueLink'>
           Click here to view table legend
         </a>
       )}
       {openLegend && (
         <div className={`legend-box`}>
-          <h2>Table Legend</h2>
+          <h2 className='font-bold'>Table Legend</h2>
           <ul className='flex flex-col items-start my-4'>
             {Object.values(tooltipIcons).map((value: any, index) => {
               return (
@@ -27,11 +27,11 @@ export const ActivitiesGapLegend: React.FC = () => {
             })}
           </ul>
           <Button variant='outline' onClick={() => setOpenLegend(false)}>
-            <FontAwesomeIcon icon={faTimes} className='h-4 mr-2' />
-            Dismiss
+            <FontAwesomeIcon icon={faTimes} className='h-4 mr-2 font-bold text-bcBluePrimary' />
+            <span className='text-bcBluePrimary'>Dismiss</span>
           </Button>
         </div>
       )}
-    </>
+    </div>
   );
 };

--- a/apps/web/src/components/ActivitiesGapLegend.tsx
+++ b/apps/web/src/components/ActivitiesGapLegend.tsx
@@ -7,7 +7,7 @@ import { tooltipIcons } from '../common';
 export const ActivitiesGapLegend: React.FC = () => {
   const [openLegend, setOpenLegend] = useState(false);
   return (
-    <div className='flex-1 p-2'>
+    <div className='flex-initial p-2'>
       {!openLegend && (
         <a href='#' onClick={() => setOpenLegend(true)} className='font-bold text-bcBlueLink'>
           Click here to view table legend

--- a/apps/web/src/components/PageTitle.tsx
+++ b/apps/web/src/components/PageTitle.tsx
@@ -5,12 +5,12 @@ export interface PageTitleProps {
 
 export const PageTitle: React.FC<PageTitleProps> = ({ title, description, children }) => {
   return (
-    <>
+    <div className="">
       <div className='flex items-center space-x-2 p-2'>
         {children}
         <h1 className='text-xl flex-col items-start'>{title}</h1>
       </div>
       <p className='text-sm text-gray-400 p-2'>{description}</p>
-    </>
+    </div>
   );
 };

--- a/apps/web/src/components/PageTitle.tsx
+++ b/apps/web/src/components/PageTitle.tsx
@@ -5,7 +5,7 @@ export interface PageTitleProps {
 
 export const PageTitle: React.FC<PageTitleProps> = ({ title, description, children }) => {
   return (
-    <div className="">
+    <div className=''>
       <div className='flex items-center space-x-2 p-2'>
         {children}
         <h1 className='text-xl flex-col items-start'>{title}</h1>

--- a/apps/web/src/components/PlanningContent.tsx
+++ b/apps/web/src/components/PlanningContent.tsx
@@ -25,7 +25,7 @@ export const PlanningContent: React.FC<PlanningContentProps> = ({ step, formTitl
     }
   };
   return (
-    <div className='flex-1 flex flex-col min-h-0'>
+    <div className='flex-1 flex flex-col min-h-0 min-w-0'>
       <p className='flex-none sr-only'>
         {step <= step ? `Form step ${step} of ${step}` : 'Form Complete'}
       </p>

--- a/apps/web/src/components/PlanningWrapper.tsx
+++ b/apps/web/src/components/PlanningWrapper.tsx
@@ -40,9 +40,9 @@ const WrapperContent = () => {
   }, [canProceedToNext]);
 
   return (
-    <div className='flex-1 flex flex-col min-h-0'>
+    <div className='flex-1 flex flex-col min-h-0 min-w-0'>
       <div
-        className='w-full flex items-center justify-between print:hidden rounded border-2 bg-white p-1 mt-4'
+        className='flex overflow-auto items-center justify-between print:hidden rounded border-2 bg-white p-1 mt-4'
         aria-hidden
       >
         <div className='flex items-center space-x-2'>

--- a/apps/web/src/components/planning/Occupation.tsx
+++ b/apps/web/src/components/planning/Occupation.tsx
@@ -50,7 +50,7 @@ export const Occupation: React.FC<OccupationProps> = ({ title }) => {
             enableReinitialize={true}
           >
             {({ values }) => (
-              <div className='flex-1 flex flex-col min-h-0 p-2'>
+              <div className='flex-1 flex flex-col min-h-0 min-w-0 p-2'>
                 <p className='text-sm font-extralight font-sans text-gray-400'>
                   {values.occupation?.length} occupations selected
                 </p>

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -6,9 +6,9 @@ import { PlanningWrapper } from '@components';
 const Home: NextPage = () => {
   return (
     <>
-      <div className='flex overflow-x-hidden h-screen mr-auto'>
+      <div className='flex w-full overflow-x-hidden h-screen'>
         <Sidebar />
-        <div className='h-screen flex flex-col w-full p-3'>
+        <div className='h-screen flex flex-col flex-1 min-h-0 min-w-0 p-3'>
           <Header />
           <PlanningWrapper />
         </div>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -18,7 +18,7 @@ body,
 }
 
 .planning-form-box {
-  @apply flex-1 flex flex-col min-h-0 overflow-auto w-full border-2 bg-white rounded p-3 mt-4;
+  @apply flex-1 flex flex-col min-h-0 min-w-0 overflow-auto border-2 bg-white rounded p-3 mt-4;
 }
 
 .occupation-item-box {


### PR DESCRIPTION
- Scrolls on horizontal overflow
- Doesn't go past the screen size up or right
- Makes the entire area scroll on overflow.
- Fixed Issue 1 of [TBCM-62] (wrong colours on the button)

To-do:
- Technically not the desired outcome. Need to split the first col 
  of headers and data and the rest of the data into two divs that 
  would scroll separately. Leaving as is for the MVP.
  