### PR TITLE
Added build step before export for web

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,7 @@ build-api:
 
 build-web:
 	@echo "++\n***** Building Web for AWS\n++"
+	@yarn workspace @tbcm/web build
 	@yarn workspace @tbcm/web export
 	@mv ./apps/web/out ./terraform/build/app
 	@echo "++\n*****"


### PR DESCRIPTION
It looks like the "build-web" makefile command was missing a build step, causing the export step to fail type checking.

 
<img width="791" alt="Screenshot 2023-09-19 at 10 36 07 AM" src="https://github.com/bcgov/MOH_TeamBasedCare/assets/54554766/dd4a9f17-c5a9-4571-998b-a83f25d750fe">
