### PR TITLE
Changing API lambda source to s3

### DIFF
--- a/terraform/variable.tf
+++ b/terraform/variable.tf
@@ -7,6 +7,7 @@ variable "app_sources" {}
 variable "target_env" {}
 variable "domain" {}
 variable "app_sources_bucket" {}
+variable "api_sources_bucket" {}
 
 variable "function_memory_mb" {
   default = "2048"


### PR DESCRIPTION
Migrating away from Lambda direct upload because of 50mb resource limit. Moving to S3 instead.

This PR creates a new bucket for API zip to reside in, and lambda references it for its source.