### PR TITLE
[TBCM-183] Migrate away from legacy Origin Access identity to Origin Access Control for the App distribution

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -10,7 +10,7 @@ resource "aws_s3_bucket" "api" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.api_kms_key.id
+        kms_master_key_id = aws_kms_key.api_kms_key.arn
         sse_algorithm = "aws:kms"
       }
     }

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,5 +1,41 @@
 resource "aws_kms_key" "app_kms_key" {}
 
+resource "aws_kms_key_policy" "app_kms_key_policy" {
+  key_id = aws_kms_key.app_kms_key.id
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "Enable IAM User Permissions",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : "arn:aws:iam::${var.target_aws_account_id}:root"
+        },
+        "Action" : "kms:*",
+        "Resource" : "*"
+      },
+      {
+        "Sid" : "Allow use of the key",
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "cloudfront.amazonaws.com"
+        },
+        "Action" : [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey*"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "AWS:SourceArn" : "arn:aws:cloudfront::${var.target_aws_account_id}:distribution/${aws_cloudfront_distribution.app.id}"
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_s3_bucket" "app" {
   bucket = var.app_sources_bucket
   acl    = "private"
@@ -9,8 +45,8 @@ resource "aws_s3_bucket" "app" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.app_kms_key.id
-        sse_algorithm = "aws:kms"
+        kms_master_key_id = aws_kms_key.app_kms_key.arn
+        sse_algorithm     = "aws:kms"
       }
     }
   }
@@ -22,6 +58,7 @@ resource "aws_s3_bucket_policy" "app" {
     Version = "2012-10-17"
     Statement = [
       {
+        Sid      = "AllowLegacyOAIReadOnly"
         Effect   = "Allow"
         Action   = "s3:GetObject"
         Resource = "${aws_s3_bucket.app.arn}/*"
@@ -38,17 +75,31 @@ resource "aws_s3_bucket_policy" "app" {
         }
       },
       {
-        Sid = "IPAllow"
-        Effect = "Deny"
+        Sid       = "IPAllow"
+        Effect    = "Deny"
         Principal = "*"
-        Action = "s3:*"
-        Resource = [ "${aws_s3_bucket.app.arn}", "${aws_s3_bucket.app.arn}/*" ]
+        Action    = "s3:*"
+        Resource  = ["${aws_s3_bucket.app.arn}", "${aws_s3_bucket.app.arn}/*"]
         Condition = {
           Bool = {
             "aws:SecureTransport" = "false"
           }
         }
-      }
+      },
+      {
+        Sid    = "AllowCloudFrontServicePrincipalReadOnly",
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        },
+        Action   = "s3:GetObject",
+        Resource = "${aws_s3_bucket.app.arn}/*",
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = "arn:aws:cloudfront::${var.target_aws_account_id}:distribution/${aws_cloudfront_distribution.app.id}"
+          }
+        }
+      },
     ]
   })
 }

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -44,6 +44,13 @@ resource "aws_cloudfront_function" "request" {
   code     = file("${path.module}/cloudfront/request.js")
 }
 
+resource "aws_cloudfront_origin_access_control" "app_oac" {
+  name                              = "app_oac"
+  description                       = "Origin Access Control for App distribution"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
 
 resource "aws_cloudfront_distribution" "app" {
   comment = local.app_name
@@ -53,10 +60,7 @@ resource "aws_cloudfront_distribution" "app" {
   origin {
     domain_name = aws_s3_bucket.app.bucket_regional_domain_name
     origin_id   = local.s3_origin_id
-
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.app.cloudfront_access_identity_path
-    }
+    origin_access_control_id = aws_cloudfront_origin_access_control.app_oac.id
   }
 
   origin {


### PR DESCRIPTION
KMS Keys for CloudFront Distribution doesn't work with the legacy Origin Access Identify. Migrating to the latest Origin Access Control.

Good reads:
1. [Signing CloudFront URLs with aws:kms encryption | AWS re:Post (repost.aws)](https://repost.aws/questions/QUcCvy-SqtRQC3xfTbl_RXQQ/signing-cloudfront-urls-with-aws-kms-encryption)
2. [amazon s3 - KMS.UnrecognizedClientException while accessing ksm encrypted s3 bucket - Stack Overflow](https://stackoverflow.com/questions/74613120/kms-unrecognizedclientexception-while-accessing-ksm-encrypted-s3-bucket)
3. [Amazon CloudFront introduces Origin Access Control (OAC)](https://aws.amazon.com/blogs/networking-and-content-delivery/amazon-cloudfront-introduces-origin-access-control-oac/)

--
This PR fixes the below error:
<img width="845" alt="image" src="https://github.com/bcgov/MOH_TeamBasedCare/assets/87394256/98cac405-4958-4093-97ad-b5a90ca4a702">



