### PR TITLE
fix activity-unit relation in bulk-upload; fix tfooter

### DIFF
--- a/apps/api/src/care-activity/care-activity-bulk.service.ts
+++ b/apps/api/src/care-activity/care-activity-bulk.service.ts
@@ -325,7 +325,7 @@ export class CareActivityBulkService {
     );
 
     // upsert care activities
-    await this.careActivityService.upsertCareActivities(partialCareActivities);
+    await this.careActivityService.saveCareActivities(partialCareActivities);
 
     // process allowed activity
     const allowedActivities = await this.processAllowedActivities(data, careActivityDisplayNames);

--- a/apps/api/src/care-activity/care-activity.service.ts
+++ b/apps/api/src/care-activity/care-activity.service.ts
@@ -251,13 +251,9 @@ export class CareActivityService {
     await this.careActivityRepo.remove(careActivity);
   }
 
-  async upsertCareActivities(partials: Partial<CareActivity>[]) {
-    return this.careActivityRepo.upsert(
+  async saveCareActivities(partials: Partial<CareActivity>[]) {
+    return this.careActivityRepo.save(
       partials.map(partial => this.careActivityRepo.create(partial)),
-      {
-        skipUpdateIfNoValuesChanged: true,
-        conflictPaths: ['name'],
-      },
     );
   }
 

--- a/apps/api/src/care-activity/entity/care-activity.entity.ts
+++ b/apps/api/src/care-activity/entity/care-activity.entity.ts
@@ -45,8 +45,8 @@ export class CareActivity extends CustomBaseEntity {
   @Column({ type: 'enum', enum: ClinicalType, nullable: true })
   clinicalType?: ClinicalType;
 
-  @ManyToMany(() => Unit, { cascade: true })
-  @JoinTable()
+  @ManyToMany(() => Unit, unit => unit.careActivities, { cascade: true })
+  @JoinTable({ name: 'care_activity_care_locations_unit' })
   careLocations: Unit[];
 
   @BeforeInsert()

--- a/apps/api/src/database/scripts/seed-service.ts
+++ b/apps/api/src/database/scripts/seed-service.ts
@@ -126,9 +126,9 @@ export class SeedService {
         if (!headers) {
           headers = Object.keys(data);
         }
-        bundleName = (!data[headers[1]] ? bundleName : data[headers[1]]).trim().replace(/"/g, '');
-        const activityName = data[headers[0]].trim().replace(/"/g, '');
-        const careLocation = 'Acute care medicine';
+        bundleName = data['Care activity bundle'].trim().replace(/"/g, '');
+        const activityName = data['Care activity'].trim().replace(/"/g, '');
+        const careLocation = data['Care setting'].trim().replace(/"/g, '');
         careLocations.add(careLocation);
 
         let activityList: {
@@ -140,11 +140,11 @@ export class SeedService {
         if (bundleName in bundleVsCareActivity) {
           activityList = bundleVsCareActivity[bundleName];
         }
-        const activityType = data[headers[2]].trim().replace(/"/g, '');
+        const activityType = data['Aspect of practice'].trim().replace(/"/g, '');
 
         activityList.push({ name: activityName, activityType, careLocation });
         bundleVsCareActivity[bundleName] = activityList;
-        for (let index = 3; index < headers.length; index++) {
+        for (let index = 4; index < headers.length; index++) {
           const e = headers[index];
           let action: string = data[e];
           let allowedAction;

--- a/apps/api/src/unit/entity/unit.entity.ts
+++ b/apps/api/src/unit/entity/unit.entity.ts
@@ -1,6 +1,7 @@
 import { cleanText } from 'src/common/utils';
-import { BeforeInsert, BeforeUpdate, Column, Entity, Index } from 'typeorm';
+import { BeforeInsert, BeforeUpdate, Column, Entity, Index, ManyToMany } from 'typeorm';
 import { CustomBaseEntity } from '../../common/custom-base.entity';
+import { CareActivity } from 'src/care-activity/entity/care-activity.entity';
 
 @Entity()
 export class Unit extends CustomBaseEntity {
@@ -10,6 +11,9 @@ export class Unit extends CustomBaseEntity {
 
   @Column({ type: 'varchar', length: 255, nullable: false })
   displayName: string;
+
+  @ManyToMany(() => CareActivity, activity => activity.careLocations)
+  careActivities: CareActivity[];
 
   @BeforeInsert()
   @BeforeUpdate()

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenException,
   Injectable,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import {
   Authorities,
@@ -40,7 +41,7 @@ export class UserService {
       this.logger.error('user.service.ts :: resolveUser');
       this.logger.error('Cannot resolve user due to invalid email');
       this.logger.error(`keycloak email: ${keycloakUser.email}`);
-      throw new BadRequestException({ message: 'Cannot resolve user due to invalid email' });
+      throw new UnauthorizedException({ message: 'Cannot resolve user due to invalid email' });
     }
 
     // find existing user

--- a/apps/web/src/components/content-management/care-activities/list.tsx
+++ b/apps/web/src/components/content-management/care-activities/list.tsx
@@ -101,13 +101,17 @@ const TableFooter: React.FC<TableFooterProps> = ({
   onPageOptionsChange,
 }) => {
   return (
-    <td colSpan={100}>
-      <Pagination
-        id='tbcm-care-terminologies-list-table'
-        pageOptions={{ pageIndex, pageSize, total }}
-        onChange={onPageOptionsChange}
-      />
-    </td>
+    <tfoot>
+      <tr>
+        <td colSpan={100}>
+          <Pagination
+            id='tbcm-care-terminologies-list-table'
+            pageOptions={{ pageIndex, pageSize, total }}
+            onChange={onPageOptionsChange}
+          />
+        </td>
+      </tr>
+    </tfoot>
   );
 };
 

--- a/apps/web/src/components/occupational-scope/ScopeOfPracticeList.tsx
+++ b/apps/web/src/components/occupational-scope/ScopeOfPracticeList.tsx
@@ -52,7 +52,11 @@ const TableBody: React.FC<TableBodyProps> = ({ allowedActivities = [] }) => {
   return (
     <tbody>
       {allowedActivities.length === 0 && (
-        <AppErrorMessage message='No care activities found with the matching filter' />
+        <tr>
+          <td colSpan={100}>
+            <AppErrorMessage message='No care activities found with the matching filter' />
+          </td>
+        </tr>
       )}
 
       {allowedActivities?.map((allowedActivity: AllowedActivityByOccupation, index: number) => (
@@ -81,13 +85,17 @@ const TableFooter: React.FC<TableFooterProps> = ({
   onPageOptionsChange,
 }) => {
   return (
-    <td colSpan={100}>
-      <Pagination
-        id='tbcm-occupational-scope-of-practice-list-table'
-        pageOptions={{ pageIndex, pageSize, total }}
-        onChange={onPageOptionsChange}
-      />
-    </td>
+    <tfoot>
+      <tr>
+        <td colSpan={100}>
+          <Pagination
+            id='tbcm-occupational-scope-of-practice-list-table'
+            pageOptions={{ pageIndex, pageSize, total }}
+            onChange={onPageOptionsChange}
+          />
+        </td>
+      </tr>
+    </tfoot>
   );
 };
 

--- a/apps/web/src/components/user-management/list.tsx
+++ b/apps/web/src/components/user-management/list.tsx
@@ -160,13 +160,17 @@ const TableFooter: React.FC<TableFooterProps> = ({
   onPageOptionsChange,
 }) => {
   return (
-    <td colSpan={100}>
-      <Pagination
-        id='tbcm-user-management-list-table'
-        pageOptions={{ pageIndex, pageSize, total }}
-        onChange={onPageOptionsChange}
-      />
-    </td>
+    <tfoot>
+      <tr>
+        <td colSpan={100}>
+          <Pagination
+            id='tbcm-user-management-list-table'
+            pageOptions={{ pageIndex, pageSize, total }}
+            onChange={onPageOptionsChange}
+          />
+        </td>
+      </tr>
+    </tfoot>
   );
 };
 


### PR DESCRIPTION
### Issues

- Occupation details doen't show new allowed activities uploaded in bulk.
- Warning related to tfooter

### Fixes

- use `save` instead of `upsert` to save activity-unit relations
- fix tfooter
- return unauthorized error instead of bad request when it fails to resolve the user