### PR TITLE
fix occupation scopes by unit

### DIFF
--- a/apps/api/src/care-activity/entity/care-activity.entity.ts
+++ b/apps/api/src/care-activity/entity/care-activity.entity.ts
@@ -52,8 +52,7 @@ export class CareActivity extends CustomBaseEntity {
   @BeforeInsert()
   @BeforeUpdate()
   updateDisplayName(): void {
-    if (this.name) {
-      this.displayName = this.name;
+    if (this.displayName) {
       this.name = cleanText(this.name);
     }
   }


### PR DESCRIPTION
- list activities related to multiple units in separate rows
- sort occupations by name in download sheet
- fix updating occupation scope when updating for the same activity but different care settings
