### PR TITLE
list duplicate activities for each unit on cms table

### DIFF
--- a/apps/api/src/care-activity/care-activity.controller.ts
+++ b/apps/api/src/care-activity/care-activity.controller.ts
@@ -90,11 +90,11 @@ export class CareActivityController {
     await this.careActivityService.updateCareActivity(id, data);
   }
 
-  @Delete(':id')
+  @Delete(':id/:unitName')
   @HttpCode(HttpStatus.NO_CONTENT)
   @AllowRoles({ roles: [Role.CONTENT_ADMIN] })
-  async removeCareActivity(@Param('id') id: string) {
-    await this.careActivityService.removeCareActivity(id);
+  async removeCareActivity(@Param('id') id: string, @Param('unitName') unitName: string) {
+    await this.careActivityService.removeCareActivity(id, unitName);
   }
 
   /** CMS Bulk */

--- a/apps/web/src/components/content-management/care-activities/list.tsx
+++ b/apps/web/src/components/content-management/care-activities/list.tsx
@@ -1,9 +1,4 @@
-import {
-  CareActivitiesCMSFindSortKeys,
-  CareActivityCMSRO,
-  formatDate,
-  SortOrder,
-} from '@tbcm/common';
+import { CareActivitiesCMSFindSortKeys, CareActivityCMSRO, SortOrder } from '@tbcm/common';
 import { isOdd } from 'src/common/util';
 import { Button } from '../../Button';
 import { Spinner } from '../../generic/Spinner';
@@ -22,9 +17,9 @@ const TableHeader: React.FC<TableHeaderProps> = ({ sortKey, sortOrder, onSortCha
 
   const headers = [
     { label: 'Care activities', name: CareActivitiesCMSFindSortKeys.DISPLAY_NAME },
+    { label: 'Care Setting', name: CareActivitiesCMSFindSortKeys.CARE_SETTING_NAME },
     { label: 'Bundle', name: CareActivitiesCMSFindSortKeys.BUNDLE_NAME },
     { label: 'Last updated by', name: CareActivitiesCMSFindSortKeys.UPDATED_BY },
-    { label: 'Last updated on', name: CareActivitiesCMSFindSortKeys.UPDATED_AT },
     { label: '' },
   ];
 
@@ -63,9 +58,9 @@ const TableBody: React.FC<TableBodyProps> = ({
       {careActivities?.map((careActivity, index: number) => (
         <tr className={`${isOdd(index) ? 'item-box-gray' : 'item-box-white'}`} key={`row${index}`}>
           <td className={tdStyles}>{careActivity.name}</td>
+          <td className={tdStyles}>{careActivity.unitName || '-'}</td>
           <td className={tdStyles}>{careActivity.bundleName || '-'}</td>
           <td className={tdStyles}>{careActivity.updatedBy || '-'}</td>
-          <td className={tdStyles}>{formatDate(careActivity.updatedAt) || '-'}</td>
           <td className={`${tdStyles}`}>
             <div className='flex justify-end gap-4'>
               {false && (

--- a/apps/web/src/services/useCMSCareActivityDelete.ts
+++ b/apps/web/src/services/useCMSCareActivityDelete.ts
@@ -8,7 +8,7 @@ export const useCMSCareActivityDelete = () => {
 
   const handleSubmit = (careActivity: CareActivityCMSRO, cb?: () => void) => {
     const config = {
-      endpoint: `${API_ENDPOINT.CARE_ACTIVITY}/${careActivity.id}`,
+      endpoint: `${API_ENDPOINT.CARE_ACTIVITY}/${careActivity.id}/${careActivity.unitName}`,
       method: REQUEST_METHOD.DELETE,
     };
 

--- a/packages/common/src/constants/sortKeys.ts
+++ b/packages/common/src/constants/sortKeys.ts
@@ -15,6 +15,7 @@ export enum CareActivitiesFindSortKeys {
 
 export enum CareActivitiesCMSFindSortKeys {
   DISPLAY_NAME = 'displayName',
+  CARE_SETTING_NAME = 'careSettingName',
   BUNDLE_NAME = 'bundleName',
   UPDATED_BY = 'updatedBy',
   UPDATED_AT = 'updatedAt',

--- a/packages/common/src/ro/careActivity.ro.ts
+++ b/packages/common/src/ro/careActivity.ro.ts
@@ -7,7 +7,7 @@ export class CareActivityRO {
   id!: string;
 
   @Expose()
-  name: string;
+  name!: string;
 
   @Expose()
   activityType!: CareActivityType;
@@ -17,8 +17,6 @@ export class CareActivityRO {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(data: any) {
-    // data: as CareActivity; can't expose entities to common package
     Object.assign(this, data);
-    this.name = data.displayName;
   }
 }

--- a/packages/common/src/ro/careActivityCMS.ro.ts
+++ b/packages/common/src/ro/careActivityCMS.ro.ts
@@ -4,19 +4,19 @@ import { CareActivityRO } from './careActivity.ro';
 @Exclude()
 export class CareActivityCMSRO extends CareActivityRO {
   @Expose()
-  bundleName: string;
+  bundleName!: string;
 
   @Expose()
   updatedAt!: Date;
 
   @Expose()
-  updatedBy: string;
+  updatedBy!: string;
+
+  @Expose()
+  unitName!: string;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(data: any) {
     super(data);
-
-    this.bundleName = data.bundle?.displayName;
-    this.updatedBy = data.updatedBy?.displayName;
   }
 }


### PR DESCRIPTION
- list duplicate activities for each unit on CMS table
- delete relation of care activity and unit when there are multiple relations
- delete care activity with one unit relation

![image](https://github.com/user-attachments/assets/8e8d7fe9-4069-4583-a5f9-c20253c1fe0d)
