### PR TITLE
Express upgrade to satisfy AWS version

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -68,7 +68,7 @@
     "@nestjs/schematics": "11.0.7",
     "@nestjs/testing": "11.1.6",
     "@types/aws-lambda": "8.10.84",
-    "@types/express": "4.17.13",
+    "@types/express": "5",
     "@types/js-yaml": "4.0.5",
     "@types/multer": "1.4.11",
     "@types/node": "22.15.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3757,7 +3757,7 @@ __metadata:
     "@nestjs/typeorm": "npm:11.0.0"
     "@tbcm/common": "npm:1.0.1"
     "@types/aws-lambda": "npm:8.10.84"
-    "@types/express": "npm:4.17.13"
+    "@types/express": "npm:5"
     "@types/js-yaml": "npm:4.0.5"
     "@types/jsonwebtoken": "npm:8.5.8"
     "@types/multer": "npm:1.4.11"
@@ -4151,18 +4151,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-serve-static-core@npm:^4.17.18":
-  version: 4.19.6
-  resolution: "@types/express-serve-static-core@npm:4.19.6"
-  dependencies:
-    "@types/node": "npm:*"
-    "@types/qs": "npm:*"
-    "@types/range-parser": "npm:*"
-    "@types/send": "npm:*"
-  checksum: 10/a2e00b6c5993f0dd63ada2239be81076fe0220314b9e9fde586e8946c9c09ce60f9a2dd0d74410ee2b5fd10af8c3e755a32bb3abf134533e2158142488995455
-  languageName: node
-  linkType: hard
-
 "@types/express-serve-static-core@npm:^5.0.0":
   version: 5.0.7
   resolution: "@types/express-serve-static-core@npm:5.0.7"
@@ -4184,7 +4172,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express@npm:*":
+"@types/express@npm:*, @types/express@npm:5":
   version: 5.0.3
   resolution: "@types/express@npm:5.0.3"
   dependencies:
@@ -4192,18 +4180,6 @@ __metadata:
     "@types/express-serve-static-core": "npm:^5.0.0"
     "@types/serve-static": "npm:*"
   checksum: 10/bb6f10c14c8e3cce07f79ee172688aa9592852abd7577b663cd0c2054307f172c2b2b36468c918fed0d4ac359b99695807b384b3da6157dfa79acbac2226b59b
-  languageName: node
-  linkType: hard
-
-"@types/express@npm:4.17.13":
-  version: 4.17.13
-  resolution: "@types/express@npm:4.17.13"
-  dependencies:
-    "@types/body-parser": "npm:*"
-    "@types/express-serve-static-core": "npm:^4.17.18"
-    "@types/qs": "npm:*"
-    "@types/serve-static": "npm:*"
-  checksum: 10/20783f6b8a0eec68d06c9478fd55bfe98ff747485316b585b3d637ca472811a1a2664b12b4b5014dc4127a2ed32c6856268228bafb2ed7840baf2a23662a1def
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Upgrading Express to v5 due to NestJS 11 working with v5 as a default.