### PR TITLE
Adding body checker for exception handler

### DIFF
--- a/apps/api/src/common/error-exception.filter.ts
+++ b/apps/api/src/common/error-exception.filter.ts
@@ -65,11 +65,13 @@ export class ErrorExceptionFilter implements ExceptionFilter {
 
     const privateKeys: string[] = ['password', 'payload'];
     const body = typeof request.body === 'string' ? JSON.parse(request.body) : request.body;
-    privateKeys.forEach(key => {
-      if (body[key]) {
-        delete body[key];
-      }
-    });
+    if (body && typeof body === 'object') {
+      privateKeys.forEach(key => {
+        if (body[key]) {
+          delete body[key];
+        }
+      });
+    }
 
     // Log errors
     this.logger.error(flattenedException, 'ExceptionFilter');


### PR DESCRIPTION
Getting the error `TypeError: Cannot read properties of undefined` for a property in `at /var/task/api/common/error-exception.filter.js:52:21`, this PR fixes that by type checking before accessing. Another PR will be needed to resolve the actual error.