### PR TITLE
Fixing deployment filters on Bastion

### DIFF
--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -6,10 +6,14 @@ data "aws_ami" "amzn_linux2" {
     values = ["amazon"]
   }
 
-
   filter {
     name   = "name"
     values = ["amzn2-ami-hvm*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
   }
 
   owners = ["amazon"]


### PR DESCRIPTION
The Bastion filter was set to hit an arm instance while the AWS is showing a x86 instance. This is to make sure we target the instance AWS is providing us.