### PR TITLE
build: enforce min node.js version 22.22.2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:22.22.2-alpine
 
 # RUN yarn set version berry
 # Copying repo resources

--- a/apps/api/.npmrc
+++ b/apps/api/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,9 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": ">=22.22.2"
+  },
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "echo \"Building @tbcm/api\" && nest build",

--- a/apps/web/.npmrc
+++ b/apps/web/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,6 +2,9 @@
   "name": "@tbcm/web",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22.22.2"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "Team based care mapping app packages",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.22.2"
   },
   "scripts": {
     "format:staged": "yarn pretty-quick --staged",


### PR DESCRIPTION
Due to Nodejs security advisory (AV26-277):
https://www.cyber.gc.ca/en/alerts-advisories/nodejs-security-advisory-av26-277

Node.js 22 must be at least 22.22.2 to prevent AV26-277.
- added >=22.22.2 to engines->node in package.json files
- added .npmrc with engine-strict=true to each app

I was unable to do any testing locally but I successfully built and launched the application. I verified that Node.js version 22.22.2 is used on all 3 application containers.